### PR TITLE
fix: add support for classes without package

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.yarnpkg.com/

--- a/lib/parser/cobertura/$coverage.js
+++ b/lib/parser/cobertura/$coverage.js
@@ -64,10 +64,22 @@ class Coverage {
 
   addClass (tag) {
     if (!this._$package) {
-      throw new Error('Need a package to add a class')
+      this.addPackage({ 
+        name: 'package', 
+        attributes: {
+          name: 'default',
+          'line-rate': -1,
+          'branch-rate': -1
+        }
+      }) 
     }
 
     this._$class = this._$package.addClass(tag)
+
+    if ((this._$package.name === 'default') && this._$class.filename.length) {
+      this._$package.name = this._$class.filename.split('/')[0]
+    }
+    
     this._$class.setPackageName(this._$package.name)
 
     this.classes.push(this._$class)

--- a/lib/parser/cobertura/$package.js
+++ b/lib/parser/cobertura/$package.js
@@ -25,6 +25,12 @@ class $Package {
     this.classes = []
   }
 
+  set name (value) {
+    if (value && value.length > 0) {
+      this._name = value
+    }
+  }
+
   get name () {
     return this._name
   }


### PR DESCRIPTION
Create a default package when none has been added by cobertura formatter.